### PR TITLE
Calculator service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
   - 2.3.4
+addons:
+  chrome: stable
 script:
   - bundle exec rspec
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'uglifier', '>= 1.3.0'
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'capybara', '~> 2.13'
+  gem 'chromedriver-helper'
   gem 'rspec-rails', '~> 3.5'
   gem 'rubocop', require: false
   gem 'rubocop-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ end
 
 group :test do
   gem 'codecov', require: false
+  gem 'rails-controller-testing'
   gem 'simplecov', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.7.0)
+      io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.3.0)
     bindex (0.5.0)
@@ -54,6 +56,9 @@ GEM
       xpath (~> 2.0)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.1.0)
+      archive-zip (~> 0.7.0)
+      nokogiri (~> 1.6)
     codecov (0.1.10)
       json
       simplecov
@@ -87,6 +92,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.0)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -245,6 +251,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara (~> 2.13)
+  chromedriver-helper
   codecov
   coffee-rails (~> 4.2)
   http

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.4)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -248,6 +252,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.7)
   rails (~> 5.1.4)
+  rails-controller-testing
   rspec-rails (~> 3.5)
   rubocop
   rubocop-rspec

--- a/app/assets/javascripts/calculator.js
+++ b/app/assets/javascripts/calculator.js
@@ -1,12 +1,23 @@
 var autocomplete;
 
 function initAutocomplete() {
+  var addressField = document.getElementById('address');
   var options = {
     types: ['(regions)']
   }
 
-  autocomplete = new google.maps.places.Autocomplete(document.getElementById('address'), options);
+  autocomplete = new google.maps.places.Autocomplete(addressField, options);
   autocomplete.addListener('place_changed', onAddressSelect);
+
+  if (addressField !== null) {
+    addressField.addEventListener('keydown', onAddressKeydown);
+  }
+}
+
+function onAddressKeydown(event) {
+  if (event.keyCode === 13) {
+    event.preventDefault(); // prevent submit when hitting enter on google suggestion
+  }
 }
 
 function onAddressSelect() {

--- a/app/controllers/calculator_controller.rb
+++ b/app/controllers/calculator_controller.rb
@@ -1,5 +1,16 @@
 class CalculatorController < ApplicationController
   def new; end
 
-  def create; end
+  def create
+    long_term_income = params[:long_term_income].to_f
+    airbnb_income = AirbnbScrapeService.new(params[:latitude], params[:longitude]).call
+
+    if airbnb_income
+      @result = CalculatorService.new(long_term_income, airbnb_income).call
+
+      render 'result'
+    else
+      redirect_to new_calculator_path, alert: 'There was an error when trying to fetch Airbnb data.'
+    end
+  end
 end

--- a/app/helpers/calculator_helper.rb
+++ b/app/helpers/calculator_helper.rb
@@ -1,0 +1,9 @@
+module CalculatorHelper
+  def more_or_less(profitable)
+    profitable ? 'more' : 'less'
+  end
+
+  def profitable_or_not(profitable)
+    profitable ? 'is' : 'is not'
+  end
+end

--- a/app/services/airbnb_scrape_service.rb
+++ b/app/services/airbnb_scrape_service.rb
@@ -20,6 +20,6 @@ class AirbnbScrapeService
                   .get(AIRBNB_URL, params: @params)
     result = request.parse
 
-    result['data'] ? result['data']['average_income_raw'] : nil
+    result['data'] ? result['data']['average_income_raw'].to_f : nil
   end
 end

--- a/app/services/airbnb_scrape_service.rb
+++ b/app/services/airbnb_scrape_service.rb
@@ -21,5 +21,7 @@ class AirbnbScrapeService
     result = request.parse
 
     result['data'] ? result['data']['average_income_raw'].to_f : nil
+  rescue HTTP::ConnectionError, JSON::ParserError
+    nil
   end
 end

--- a/app/services/calculator_service.rb
+++ b/app/services/calculator_service.rb
@@ -6,12 +6,12 @@ class CalculatorService
 
   def call
     delta = @airbnb_income - @long_term_income
-    percentage = (delta / @long_term_income) * 100
+    percentage = (delta / (@long_term_income.nonzero? || 1)) * 100
 
     {
       airbnb_income: @airbnb_income.round(2),
       percentage: percentage.round(2),
-      delta: delta.round(2),
+      delta: delta.round(2).abs,
       profitable: delta > 0
     }
   end

--- a/app/services/calculator_service.rb
+++ b/app/services/calculator_service.rb
@@ -1,0 +1,18 @@
+class CalculatorService
+  def initialize(long_term_income, airbnb_income)
+    @long_term_income = long_term_income
+    @airbnb_income = airbnb_income
+  end
+
+  def call
+    delta = @airbnb_income - @long_term_income
+    percentage = (delta / @long_term_income) * 100
+
+    {
+      airbnb_income: @airbnb_income.round(2),
+      percentage: percentage.round(2),
+      delta: delta.round(2),
+      profitable: delta > 0
+    }
+  end
+end

--- a/app/views/calculator/new.html.erb
+++ b/app/views/calculator/new.html.erb
@@ -1,9 +1,9 @@
 <%= form_tag('/calculator') do %>
-  <%= label_tag(:average_income, 'Average long term rental income per month:') %>
-  <%= number_field_tag(:average_income, params[:average_income], class: 'form-input', id: 'average_income', required: true) %>
+  <%= label_tag(:long_term_income, 'Average long term rental income per month (USD):') %>
+  <%= number_field_tag(:long_term_income, params[:long_term_income], class: 'form-input', required: true) %>
 
   <%= label_tag(:address, 'Address:') %>
-  <%= text_field_tag(:address, params[:address], class: 'form-input', id: 'address', required: true) %>
+  <%= text_field_tag(:address, params[:address], class: 'form-input', required: true) %>
 
   <%= hidden_field_tag :latitude %>
   <%= hidden_field_tag :longitude %>

--- a/app/views/calculator/result.html.erb
+++ b/app/views/calculator/result.html.erb
@@ -1,0 +1,5 @@
+<p>You could earn an average of $<%= @result[:airbnb_income] %> per month with Airbnb.</p>
+<p>You could earn $<%= @result[:delta] %> (<%= @result[:percentage] %>%) <%= more_or_less(@result[:profitable]) %> than long term rent.</p>
+<p>It <%= profitable_or_not(@result[:profitable]) %> profitable to do Airbnb.</p>
+
+<%= link_to 'Go back to the calculator', new_calculator_path, data: { turbolinks: false } %>

--- a/app/views/calculator/result.html.erb
+++ b/app/views/calculator/result.html.erb
@@ -1,5 +1,5 @@
 <p>You could earn an average of $<%= @result[:airbnb_income] %> per month with Airbnb.</p>
-<p>You could earn $<%= @result[:delta] %> (<%= @result[:percentage] %>%) <%= more_or_less(@result[:profitable]) %> than long term rent.</p>
+<p>You would earn $<%= @result[:delta] %> (<%= @result[:percentage] %>%) <%= more_or_less(@result[:profitable]) %> than long term rent.</p>
 <p>It <%= profitable_or_not(@result[:profitable]) %> profitable to do Airbnb.</p>
 
 <%= link_to 'Go back to the calculator', new_calculator_path, data: { turbolinks: false } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   </head>
 
   <body>
+    <%= render 'shared/flash_messages' %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,3 @@
+<% flash.each do |type, value| %>
+  <%= value %>
+<% end %>

--- a/spec/features/calculator_spec.rb
+++ b/spec/features/calculator_spec.rb
@@ -121,7 +121,7 @@ feature 'Calculator', type: :feature do
         click_button('Calculate')
 
         expect(page).to have_css('p', text: /You could earn an average of \$\d+\.\d+ per month with Airbnb./)
-        expect(page).to have_css('p', text: /You could earn \$\d+\.\d+ \(\d+.\d+%\) more than long term rent./)
+        expect(page).to have_css('p', text: /You would earn \$\d+\.\d+ \(\d+.\d+%\) more than long term rent./)
         expect(page).to have_css('p', text: /It is profitable to do Airbnb./)
       end
     end
@@ -140,7 +140,7 @@ feature 'Calculator', type: :feature do
         click_button('Calculate')
 
         expect(page).to have_css('p', text: /You could earn an average of \$\d+\.\d+ per month with Airbnb./)
-        expect(page).to have_css('p', text: /You could earn \$\d+\.\d+ \(\-\d+.\d+%\) less than long term rent./)
+        expect(page).to have_css('p', text: /You would earn \$\d+\.\d+ \(\-\d+.\d+%\) less than long term rent./)
         expect(page).to have_css('p', text: /It is not profitable to do Airbnb./)
       end
     end

--- a/spec/features/calculator_spec.rb
+++ b/spec/features/calculator_spec.rb
@@ -28,7 +28,7 @@ feature 'Calculator', type: :feature do
       expect(page).to have_field('address', with: 'Goiânia - State of Goiás, Brazil')
     end
 
-    skip 'sets the latitude and longitude to the hidden fields', js: true do
+    it 'sets the latitude and longitude to the hidden fields', js: true do
       visit root_path
 
       fill_in 'long_term_income', with: '500'
@@ -39,8 +39,8 @@ feature 'Calculator', type: :feature do
       find('#address').send_keys(:down)      
       find('#address').send_keys(:enter)
 
-      # expect(find('#latitude', visible: false).value).to eq('-16.68689119999999')
-      # expect(find('#longitude', visible: false).value).to eq('-49.264794300000005')
+      expect(page).to have_selector("#latitude[value='-16.68689119999999']", visible: false)
+      expect(page).to have_selector("#longitude[value='-49.264794300000005']", visible: false)
     end
   end
 end

--- a/spec/features/calculator_spec.rb
+++ b/spec/features/calculator_spec.rb
@@ -21,8 +21,8 @@ feature 'Calculator', type: :feature do
       fill_in 'address', with: 'Goiânia'
 
       expect(page).to have_selector('.pac-item')
-      
-      find('#address').send_keys(:down)      
+
+      find('#address').send_keys(:down)
       find('#address').send_keys(:enter)
 
       expect(page).to have_field('address', with: 'Goiânia - State of Goiás, Brazil')
@@ -36,11 +36,96 @@ feature 'Calculator', type: :feature do
 
       expect(page).to have_selector('.pac-item')
 
-      find('#address').send_keys(:down)      
+      find('#address').send_keys(:down)
       find('#address').send_keys(:enter)
 
       expect(page).to have_selector("#latitude[value='-16.68689119999999']", visible: false)
       expect(page).to have_selector("#longitude[value='-49.264794300000005']", visible: false)
+    end
+
+    it 'redirects to result page after form submit', js: true do
+      visit root_path
+
+      fill_in 'long_term_income', with: '500'
+      fill_in 'address', with: 'Goiânia'
+
+      expect(page).to have_selector('.pac-item')
+
+      find('#address').send_keys(:down)
+      find('#address').send_keys(:enter)
+      click_button('Calculate')
+
+      expect(page.current_path).to eq('/calculator')
+    end
+  end
+
+  describe 'result page' do
+    it 'displays 3 paragraphs containing the result data', js: true do
+      visit root_path
+
+      fill_in 'long_term_income', with: '500'
+      fill_in 'address', with: 'Goiânia'
+
+      expect(page).to have_selector('.pac-item')
+
+      find('#address').send_keys(:down)
+      find('#address').send_keys(:enter)
+      click_button('Calculate')
+
+      expect(page).to have_selector('p', count: 3)
+    end
+
+    it 'displays a back to the calculator button', js: true do
+      visit root_path
+
+      fill_in 'long_term_income', with: '500'
+      fill_in 'address', with: 'Goiânia'
+
+      expect(page).to have_selector('.pac-item')
+
+      find('#address').send_keys(:down)
+      find('#address').send_keys(:enter)
+      click_button('Calculate')
+
+      expect(page).to have_link('Go back to the calculator', href: '/calculator/new')
+    end
+
+    context 'when airbnb is more profitable' do
+      it 'displays the desired result data', js: true do
+        visit root_path
+
+        fill_in 'long_term_income', with: '10'
+        fill_in 'address', with: 'Goiânia'
+
+        expect(page).to have_selector('.pac-item')
+
+        find('#address').send_keys(:down)
+        find('#address').send_keys(:enter)
+        click_button('Calculate')
+
+        expect(page).to have_css('p', text: /You could earn an average of \$\d+\.\d+ per month with Airbnb./)
+        expect(page).to have_css('p', text: /You could earn \$\d+\.\d+ \(\d+.\d+%\) more than long term rent./)
+        expect(page).to have_css('p', text: /It is profitable to do Airbnb./)
+      end
+    end
+
+    context 'when long term rent is more profitable' do
+      it 'displays the desired result data', js: true do
+        visit root_path
+
+        fill_in 'long_term_income', with: '10000'
+        fill_in 'address', with: 'Goiânia'
+
+        expect(page).to have_selector('.pac-item')
+
+        find('#address').send_keys(:down)
+        find('#address').send_keys(:enter)
+        click_button('Calculate')
+
+        expect(page).to have_css('p', text: /You could earn an average of \$\d+\.\d+ per month with Airbnb./)
+        expect(page).to have_css('p', text: /You could earn \$\d+\.\d+ \(\-\d+.\d+%\) less than long term rent./)
+        expect(page).to have_css('p', text: /It is not profitable to do Airbnb./)
+      end
     end
   end
 end

--- a/spec/features/calculator_spec.rb
+++ b/spec/features/calculator_spec.rb
@@ -90,6 +90,23 @@ feature 'Calculator', type: :feature do
       expect(page).to have_link('Go back to the calculator', href: '/calculator/new')
     end
 
+    it 'redirects to the calculator page when clicking on back button', js: true do
+      visit root_path
+
+      fill_in 'long_term_income', with: '500'
+      fill_in 'address', with: 'Goiânia'
+
+      expect(page).to have_selector('.pac-item')
+
+      find('#address').send_keys(:down)
+      find('#address').send_keys(:enter)
+      click_button('Calculate')
+
+      click_link('Go back to the calculator')
+
+      expect(page.current_path).to eq('/calculator/new')
+    end
+
     context 'when airbnb is more profitable' do
       it 'displays the desired result data', js: true do
         visit root_path

--- a/spec/features/calculator_spec.rb
+++ b/spec/features/calculator_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+feature 'Calculator', type: :feature do
+  describe 'root page' do
+    it 'displays long term income field' do
+      visit root_path
+
+      expect(page).to have_field('long_term_income')
+    end
+
+    it 'displays address field' do
+      visit root_path
+
+      expect(page).to have_field('address')
+    end
+
+    it 'displays the address suggestion on type', js: true do
+      visit root_path
+
+      fill_in 'long_term_income', with: '500'
+      fill_in 'address', with: 'Goiânia'
+
+      expect(page).to have_selector('.pac-item')
+      
+      find('#address').send_keys(:down)      
+      find('#address').send_keys(:enter)
+
+      expect(page).to have_field('address', with: 'Goiânia - State of Goiás, Brazil')
+    end
+
+    skip 'sets the latitude and longitude to the hidden fields', js: true do
+      visit root_path
+
+      fill_in 'long_term_income', with: '500'
+      fill_in 'address', with: 'Goiânia'
+
+      expect(page).to have_selector('.pac-item')
+
+      find('#address').send_keys(:down)      
+      find('#address').send_keys(:enter)
+
+      # expect(find('#latitude', visible: false).value).to eq('-16.68689119999999')
+      # expect(find('#longitude', visible: false).value).to eq('-49.264794300000005')
+    end
+  end
+end

--- a/spec/helpers/calculator_helper_spec.rb
+++ b/spec/helpers/calculator_helper_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe CalculatorHelper, type: :helper do
+  describe '#more_or_less' do
+    context 'when profitable param is true' do
+      it "returns 'more'" do
+        expect(helper.more_or_less(true)).to eq('more')
+      end
+    end
+
+    context 'when profitable param is false' do
+      it "returns 'less'" do
+        expect(helper.more_or_less(false)).to eq('less')
+      end
+    end
+  end
+
+  describe '#profitable_or_not' do
+    context 'when profitable param is true' do
+      it "returns 'is'" do
+        expect(helper.profitable_or_not(true)).to eq('is')
+      end
+
+      it "returns 'is not'" do
+        expect(helper.profitable_or_not(false)).to eq('is not')
+      end
+    end
+  end
+end

--- a/spec/helpers/calculator_helper_spec.rb
+++ b/spec/helpers/calculator_helper_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe CalculatorHelper, type: :helper do
       it "returns 'is'" do
         expect(helper.profitable_or_not(true)).to eq('is')
       end
+    end
 
+    context 'when profitable param is false' do
       it "returns 'is not'" do
         expect(helper.profitable_or_not(false)).to eq('is not')
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,3 +19,19 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 end
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu) }
+  )
+
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+end
+
+Capybara.javascript_driver = :headless_chrome

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,12 +26,12 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu) }
+    chromeOptions: { args: %w[headless disable-gpu] }
   )
 
   Capybara::Selenium::Driver.new app,
-    browser: :chrome,
-    desired_capabilities: capabilities
+                                 browser: :chrome,
+                                 desired_capabilities: capabilities
 end
 
 Capybara.javascript_driver = :headless_chrome

--- a/spec/requests/calculator_spec.rb
+++ b/spec/requests/calculator_spec.rb
@@ -8,4 +8,54 @@ RSpec.describe 'Calculator', type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe 'POST #create' do
+    context 'with valid params' do
+      let(:valid_params) do
+        {
+          latitude: '-16.685226',
+          longitude: '-49.265355',
+          long_term_income: '500'
+        }
+      end
+
+      it 'returns 200 as http status' do
+        post calculator_path, params: valid_params
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'assigns result as a hash' do
+        post calculator_path, params: valid_params
+
+        expect(assigns(:result)).to be_a(Hash)
+      end
+
+      it 'renders the result page' do
+        post calculator_path, params: valid_params
+
+        expect(response).to render_template('result')
+      end
+    end
+
+    context 'with invalid params' do
+      it 'returns 200 as http status' do
+        post calculator_path, params: {}
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'assigns result as a hash' do
+        post calculator_path, params: {}
+
+        expect(assigns(:result)).to be_a(Hash)
+      end
+
+      it 'renders the result page' do
+        post calculator_path, params: {}
+
+        expect(response).to render_template('result')
+      end
+    end
+  end
 end

--- a/spec/services/calculator_service_spec.rb
+++ b/spec/services/calculator_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CalculatorService do
         result = {
           airbnb_income: airbnb_income,
           percentage: -16.67,
-          delta: -100.0,
+          delta: 100.0,
           profitable: false
         }
 

--- a/spec/services/calculator_service_spec.rb
+++ b/spec/services/calculator_service_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe CalculatorService do
+  describe '#call' do
+    context 'when airbnb is more profitable' do
+      it 'returns a hash with the result' do
+        long_term_income = 1000.0
+        airbnb_income = 1200.0
+        service = described_class.new(long_term_income, airbnb_income)
+        result = {
+          airbnb_income: airbnb_income,
+          percentage: 20.0,
+          delta: 200.0,
+          profitable: true
+        }
+
+        expect(service.call).to eq(result)
+      end
+    end
+
+    context 'when long term rent is more profitable' do
+      it 'returns a hash with the result' do
+        long_term_income = 600.0
+        airbnb_income = 500.0
+        service = described_class.new(long_term_income, airbnb_income)
+        result = {
+          airbnb_income: airbnb_income,
+          percentage: -16.67,
+          delta: -100.0,
+          profitable: false
+        }
+
+        expect(service.call).to eq(result)
+      end
+    end
+  end
+end

--- a/spec/services/calculator_service_spec.rb
+++ b/spec/services/calculator_service_spec.rb
@@ -33,5 +33,53 @@ RSpec.describe CalculatorService do
         expect(service.call).to eq(result)
       end
     end
+
+    context 'when airbnb income is zero' do
+      it 'returns the result with no problems' do
+        long_term_income = 100.0
+        airbnb_income = 0.0
+        service = described_class.new(long_term_income, airbnb_income)
+        result = {
+          airbnb_income: airbnb_income,
+          percentage: -100.0,
+          delta: 100.0,
+          profitable: false
+        }
+
+        expect(service.call).to eq(result)
+      end
+    end
+
+    context 'when long term rent is zero' do
+      it 'returns the result with no problems' do
+        long_term_income = 0.0
+        airbnb_income = 100.0
+        service = described_class.new(long_term_income, airbnb_income)
+        result = {
+          airbnb_income: airbnb_income,
+          percentage: 10000.0,
+          delta: 100.0,
+          profitable: true
+        }
+
+        expect(service.call).to eq(result)
+      end
+    end
+
+    context 'when both incomes are zero' do
+      it 'returns the result with no problems' do
+        long_term_income = 0.0
+        airbnb_income = 0.0
+        service = described_class.new(long_term_income, airbnb_income)
+        result = {
+          airbnb_income: airbnb_income,
+          percentage: 0.0,
+          delta: 0.0,
+          profitable: false
+        }
+
+        expect(service.call).to eq(result)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### Changes
- Create the `CalculatorService`, service responsible for checking if Airbnb is more profitable than long term rent. It also calculates the delta between both and a percentage
- Create a result page where the results from `CalculatorService` are shown
- Create partial to display flash messages
- Prevent form submit when selecting Google autocomplete option hitting enter
- Create integration tests with Capybara